### PR TITLE
fix(Core): Update CanPacketSend signature to const WorldPacket&

### DIFF
--- a/src/BreakingNews.cpp
+++ b/src/BreakingNews.cpp
@@ -103,7 +103,7 @@ void LoadBreakingNews()
     bn_Formatted = Acore::StringFormat(_midPayloadFmt, bn_Title, bn_Body);
 }
 
-bool BreakingNewsServerScript::CanPacketSend(WorldSession* session, WorldPacket& packet)
+bool BreakingNewsServerScript::CanPacketSend(WorldSession* session, WorldPacket const& packet)
 {
     if (!bn_Enabled)
         return true;

--- a/src/BreakingNews.h
+++ b/src/BreakingNews.h
@@ -34,7 +34,7 @@ public:
     }) { }
 
 private:
-    bool CanPacketSend(WorldSession* session, WorldPacket& packet) override;
+    bool CanPacketSend(WorldSession* session, WorldPacket const& packet) override;
     std::vector<std::string> GetChunks(std::string s, uint8_t chunkSize);
     void SendChunkedPayload(Warden* warden, WardenPayloadMgr* payloadMgr, std::string payload, uint32 chunkSize);
 };


### PR DESCRIPTION
Adapts to azerothcore/azerothcore-wotlk#25063 which changes `CanPacketSend` to take `WorldPacket const&` instead of `WorldPacket&`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)